### PR TITLE
Fix Travis CI build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: node_js
 
 node_js:
-  - 10/*
+  - 10.17.0
 
 sudo: required
 


### PR DESCRIPTION
There is a known issue with node version when building with Travis CI and elementary. So you have to use the `10.17.0` node version instead.