### PR TITLE
Fix typo in encoding charset making build fail

### DIFF
--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 


### PR DESCRIPTION
There was a typo in the encoding charset of the extra French translation. This should fix build failing as discussed in #22.